### PR TITLE
fix build failure by implementing cli.Flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,41 +50,41 @@ func run() error {
 
 		`
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:        "server",
 			Value:       "https://cowyo.com",
 			Usage:       "cowyo server to use",
 			Destination: &server,
 		},
 
-		cli.BoolFlag{
+		&cli.BoolFlag{
 			Name:        "debug",
 			Usage:       "debug mode",
 			Destination: &debug,
 		},
 	}
-	app.Commands = []cli.Command{
+	app.Commands = []*cli.Command{
 		{
 			Name:    "upload",
 			Aliases: []string{"u"},
 			Usage:   "upload document",
 			Flags: []cli.Flag{
-				cli.BoolFlag{
+				&cli.BoolFlag{
 					Name:        "encrypt, e",
 					Usage:       "encrypt using passphrase",
 					Destination: &encryptFlag,
 				},
-				cli.BoolFlag{
+				&cli.BoolFlag{
 					Name:        "store, s",
 					Usage:       "store and persist after reading",
 					Destination: &store,
 				},
-				cli.BoolFlag{
+				&cli.BoolFlag{
 					Name:        "name, n",
 					Usage:       "use name of file",
 					Destination: &name,
 				},
-				cli.StringFlag{
+				&cli.StringFlag{
 					Name:        "passphrase, a",
 					Usage:       "passphrase to use for encryption",
 					Destination: &passphrase,
@@ -184,7 +184,7 @@ func run() error {
 			Aliases: []string{"d"},
 			Usage:   "download document",
 			Flags: []cli.Flag{
-				cli.StringFlag{
+				&cli.StringFlag{
 					Name:        "passphrase, a",
 					Usage:       "passphrase to use for encryption",
 					Destination: &passphrase,


### PR DESCRIPTION
`go get -u -v github.com/schollz/cowyodel` fails with:
```# github.com/schollz/cowyodel
cowyodel/main.go:53:17: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
        cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
cowyodel/main.go:60:15: cannot use cli.BoolFlag literal (type cli.BoolFlag) as type cli.Flag in array or slice literal:
        cli.BoolFlag does not implement cli.Flag (Apply method has pointer receiver)
cowyodel/main.go:66:15: cannot use []cli.Command literal (type []cli.Command) as type []*cli.Command in assignment
cowyodel/main.go:72:17: cannot use cli.BoolFlag literal (type cli.BoolFlag) as type cli.Flag in array or slice literal:
        cli.BoolFlag does not implement cli.Flag (Apply method has pointer receiver)
cowyodel/main.go:77:17: cannot use cli.BoolFlag literal (type cli.BoolFlag) as type cli.Flag in array or slice literal:
        cli.BoolFlag does not implement cli.Flag (Apply method has pointer receiver)
cowyodel/main.go:82:17: cannot use cli.BoolFlag literal (type cli.BoolFlag) as type cli.Flag in array or slice literal:
        cli.BoolFlag does not implement cli.Flag (Apply method has pointer receiver)
cowyodel/main.go:87:19: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
        cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
cowyodel/main.go:187:19: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
        cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)```

This change fixes the issue.